### PR TITLE
Enable server to reset postgres sequences after loading data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VENV_DIR := ./.venv
+TEST_SERVER_PORT := 8000
 
 rem-venv:
 	-rm -rf $(VENV_DIR)
@@ -13,5 +14,11 @@ build-release:
 	-rm -rf dist
 	$(VENV_DIR)/bin/python -m build .
 
+test-server:
+	$(VENV_DIR)/bin/uvicorn sl.dbserver.app:main --reload --port $(TEST_SERVER_PORT)
+
 push-release: build-release
 	$(VENV_DIR)/bin/twine upload dist/*
+
+test-db:
+	docker-compose up

--- a/src/sl/dbserver/__test__/fixtures.py
+++ b/src/sl/dbserver/__test__/fixtures.py
@@ -36,7 +36,18 @@ def sldb_test_seed_data() -> _t.List[_types.SeedData]:
 
 
 @_pytest.fixture(scope="function")
-def sldb_url(sldb_test_url, sldb_test_schema_module, request, sldb_test_seed_data):
+def sldb_test_reset_seq() -> bool:
+    return True
+
+
+@_pytest.fixture(scope="function")
+def sldb_url(
+    sldb_test_url,
+    sldb_test_schema_module,
+    request,
+    sldb_test_seed_data,
+    sldb_test_reset_seq,
+):
     """Creates, yields, and cleans up a testing database"""
     test_name = request.node.name
     response = _app.create_db(
@@ -49,6 +60,7 @@ def sldb_url(sldb_test_url, sldb_test_schema_module, request, sldb_test_seed_dat
                 value=sldb_test_schema_module,
             ),
             seeds=sldb_test_seed_data,
+            reset_seq=sldb_test_reset_seq,
         )
     )
     yield response.url

--- a/src/sl/dbserver/_test_app.py
+++ b/src/sl/dbserver/_test_app.py
@@ -23,6 +23,7 @@ def test_create_drop_test_db(sldb_test_url, sldb_test_schema_module):
                     type="module", value="sl.dbserver.__test__:seeds/test01.json"
                 )
             ],
+            reset_seq=True,
         )
     )
     _TC.assertTrue(_su.database_exists(response.url))
@@ -43,6 +44,21 @@ def test_create_drop_test_db(sldb_test_url, sldb_test_schema_module):
     # destroy the database, afterwards
     _app.drop_db(_types.DropDbArgs(drop_id=response.drop_id))
     _TC.assertFalse(_su.database_exists(response.url))
+
+
+def test_reset_seq(sldb_conn: _sae.Connection):
+    user_seq = sldb_conn.exec_driver_sql("SELECT last_value FROM user_id_seq").one()
+    _TC.assertEqual(user_seq, (2,))
+
+
+class TestNoResetSeq:
+    @_pytest.fixture(scope="function")
+    def sldb_test_reset_seq(self):
+        return False
+
+    def test_no_reset_seq(self, sldb_conn: _sae.Connection):
+        user_seq = sldb_conn.exec_driver_sql("SELECT last_value FROM user_id_seq").one()
+        _TC.assertEqual(user_seq, (1,))
 
 
 class TestSqlLoad:

--- a/src/sl/dbserver/app.py
+++ b/src/sl/dbserver/app.py
@@ -1,9 +1,12 @@
 import fastapi as _fapi
 import datetime as _dt
+import sqlalchemy as _sa
+import sqlalchemy.engine as _sae
 from .util.db import (
     url as _dbu_url,
     conn as _dbu_conn,
 )
+from .util import file as _fu
 from . import (
     types as _types,
     db as _db,
@@ -30,8 +33,12 @@ def create_db(args: _types.CreateDbArgs = _fapi.Body()) -> _types.CreatedDb:
     try:
         _dbu_conn.create_database(new_url)
         _db.create_schema(new_url, args.schema_def)
-        for seed_data in args.seeds:
-            _db.load_seed_data(new_url, seed_data)
+        _db.load_seed_data_list(
+            new_url,
+            args.seeds,
+            reset_seq=args.reset_seq,
+            schema=args.schema_def,
+        )
     except Exception as e:
         if not args.keep_db_on_error:
             _dbu_conn.drop_database(new_url)

--- a/src/sl/dbserver/conftest.py
+++ b/src/sl/dbserver/conftest.py
@@ -4,6 +4,7 @@ from .__test__.fixtures import (
     sldb_test_schema,
     sldb_test_schema_module,
     sldb_test_seed_data,
+    sldb_test_reset_seq,
     sldb_url,
     sldb_engine,
     sldb_conn,

--- a/src/sl/dbserver/db.py
+++ b/src/sl/dbserver/db.py
@@ -1,16 +1,21 @@
+import typing as _t
+import sqlalchemy as _sa
 import sqlalchemy.engine as _sae
 import pathlib as _pl
 from .util import file as _fu
 from . import types as _types
-from .util.db import schema as _dbus
-from .util.db import seed as _db_seed
+from .util.db import (
+    schema as _dbu_schema,
+    seed as _dbu_seed,
+    conn as _dbu_conn,
+)
 
 
 def create_schema(url: _sae.URL | str, schema: _types.SchemaDef):
     """Uses the schema definition to create the schema inside the passed database url"""
     match schema.type:
         case "sqlalchemy":
-            _dbus.load_sqlalchemy_schema(url, schema.value)
+            _dbu_schema.load_sqlalchemy_schema(url, schema.value)
 
 
 def _seed_data_from_file(fname: str) -> _types.SeedData:
@@ -38,7 +43,24 @@ def _seed_data_from_module(modname: str) -> _types.SeedData:
     return _seed_data_from_file(fname)
 
 
-def load_seed_data(url: _sae.URL | str, seed: _types.SeedData):
+def load_seed_data_list(
+    url: _sae.URL | str,
+    seeds: _t.List[_types.SeedData],
+    *,
+    reset_seq: bool,
+    schema: _types.SchemaDef,
+):
+    if len(seeds) <= 0:
+        return
+    engine = _sae.create_engine(url)
+    with _dbu_conn.disabled_constraints(engine) as conn:
+        for seed in seeds:
+            load_seed_data(conn, seed)
+        if reset_seq:
+            _reset_seq(conn, schema)
+
+
+def load_seed_data(conn: _sae.Connection, seed: _types.SeedData):
     if seed.type == "file":
         seed = _seed_data_from_file(seed.value)
     if seed.type == "module":
@@ -47,6 +69,20 @@ def load_seed_data(url: _sae.URL | str, seed: _types.SeedData):
     # at this point seed should have either a "json" or "sql" type
     match seed.type:
         case "json":
-            _db_seed.load_json_seed(url, seed.value)
+            _dbu_seed.load_json_seed(conn, seed.value)
         case "sql":
-            _db_seed.load_sql_seed(url, seed.value)
+            _dbu_seed.load_sql_seed(conn, seed.value)
+
+
+def _reset_seq(conn: _sae.Connection, schema: _types.SchemaDef):
+    if schema.type != "sqlalchemy":
+        # nothing to do
+        return
+
+    metadata = _fu.import_from_str(schema.value)
+    if not metadata or not isinstance(metadata, _sa.MetaData):
+        raise _types.ApiError(
+            message=f"Not a valid metadata module: {schema.value}"
+        ).to_httperr()
+
+    _dbu_seed.reset_pg_seq(conn, metadata)

--- a/src/sl/dbserver/types.py
+++ b/src/sl/dbserver/types.py
@@ -107,7 +107,7 @@ class CreateDbArgs(_pyd.BaseModel):
         title="Connection string",
         description=(
             "A database connection string, eg: `postgres://user:password@localhost:5432/db_name`. "
-            + "The user/password combination must have database CREATE privileges."
+            "The user/password combination must have database CREATE privileges."
         ),
     )
     append_name: str = _pyd.Field(
@@ -122,7 +122,7 @@ class CreateDbArgs(_pyd.BaseModel):
         title="With timestamp",
         description=(
             'Set to "true" to include a timestamp in a created database name. This can help '
-            + "differentiate different runs of the same test"
+            "differentiate different runs of the same test"
         ),
     )
     schema_def: SchemaDef = _pyd.Field(
@@ -147,6 +147,22 @@ class CreateDbArgs(_pyd.BaseModel):
             "By default an error while creating the database will cause the server to return the "
             "error raised and clean up the broken build. Setting this value to `true` will keep "
             "the broken database intact."
+        ),
+    )
+    reset_seq: bool = _pyd.Field(
+        default=False,
+        title="Reset sequences",
+        description=(
+            "When using a SQLAlchemy module as the schema, any autoincrement sequences in the "
+            "database will **not** be automatically set correctly to the maximum value of the "
+            "inserted items. This can lead to insert problems later, where a newly inserted "
+            "value will attempt to take an ID already taken by another item in the database. "
+            "This option **only** works when using a sqlalchemy metadata object to load the "
+            "schema, and will find all of the known autoincrementing sequences and set them equal "
+            "to the highest value in the column that the sequence is attached to. It will do "
+            "this only if seed values are loaded, and only if the schema was loaded via a "
+            "sqlalchemy MetaData object. If loading via SQL just make sure to set the sequences "
+            "properly as part of loading the seed."
         ),
     )
 

--- a/src/sl/dbserver/util/db/seed.py
+++ b/src/sl/dbserver/util/db/seed.py
@@ -17,7 +17,7 @@ def _yield_all_columns(table: _sa.Table):
     yield from table.c
 
 
-def reset_pg_increments(conn: _saeb.Connection, metadata: _sa.MetaData):
+def reset_pg_seq(conn: _saeb.Connection, metadata: _sa.MetaData):
     """When loading data with postgresql any auto-incrementing counters are not automatically
     accounted for, so this will go through every column in every table, check if it has a
     counter, and if it does, set the value of that counter to the maximum value currently held
@@ -52,7 +52,7 @@ def reset_pg_increments(conn: _saeb.Connection, metadata: _sa.MetaData):
                 )
 
 
-def load_json_seed(url: _sae.URL | str, seed: str):
+def load_json_seed(conn: _sae.Connection, seed: str):
     parsed = _fu.str_to_json(seed)
     metadata_str = parsed.get("metadata")
     if not metadata_str:
@@ -66,16 +66,12 @@ def load_json_seed(url: _sae.URL | str, seed: str):
             message="JSON Seed data does not specify any seed data"
         ).to_httperr()
 
-    engine = _sae.create_engine(url)
-    with _dbu_conn.disabled_constraints(engine) as conn:
-        _dbu_ser.deserialize_db(
-            metadata,
-            parsed,
-            conn=conn,
-        )
+    _dbu_ser.deserialize_db(
+        metadata,
+        parsed,
+        conn=conn,
+    )
 
 
-def load_sql_seed(url: _sae.URL | str, seed: str):
-    engine = _sae.create_engine(url)
-    with _dbu_conn.disabled_constraints(engine) as conn:
-        conn.execute(seed)
+def load_sql_seed(conn: _sae.Connection, seed: str):
+    conn.execute(seed)


### PR DESCRIPTION
When loading seed data into the database any sequences created by Postgres don't get triggered if the value in that column is added manually, meaning the sequences will remain at their initialized value. This adds an option to the create database call which, for sqlalchemy metadata-defined schemas, will traverse all of the known sequences and update them to be the maximum value of the column they are attached to.