### PR TITLE
Enable server to load schema from SQL

### DIFF
--- a/src/sl/dbserver/__test__/fixtures.py
+++ b/src/sl/dbserver/__test__/fixtures.py
@@ -29,6 +29,11 @@ def sldb_test_schema_module() -> str:
 
 
 @_pytest.fixture(scope="function")
+def sldb_test_schema_def(sldb_test_schema_module) -> _types.SchemaDef:
+    return _types.SchemaDef(type="sqlalchemy", value=sldb_test_schema_module)
+
+
+@_pytest.fixture(scope="function")
 def sldb_test_seed_data() -> _t.List[_types.SeedData]:
     return [
         _types.SeedData(type="module", value="sl.dbserver.__test__:seeds/test01.json")
@@ -43,7 +48,7 @@ def sldb_test_reset_seq() -> bool:
 @_pytest.fixture(scope="function")
 def sldb_url(
     sldb_test_url,
-    sldb_test_schema_module,
+    sldb_test_schema_def,
     request,
     sldb_test_seed_data,
     sldb_test_reset_seq,
@@ -55,10 +60,7 @@ def sldb_url(
             url=sldb_test_url,
             append_name=test_name,
             with_timestamp=True,
-            schema=_types.SchemaDef(
-                type="sqlalchemy",
-                value=sldb_test_schema_module,
-            ),
+            schema=sldb_test_schema_def,
             seeds=sldb_test_seed_data,
             reset_seq=sldb_test_reset_seq,
         )

--- a/src/sl/dbserver/__test__/schema.sql
+++ b/src/sl/dbserver/__test__/schema.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+CREATE TABLE alembic_version (
+    version_num VARCHAR(32) NOT NULL, 
+    CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+);
+
+-- Running upgrade  -> c0593ad90703
+
+CREATE TABLE "user" (
+    id SERIAL NOT NULL, 
+    name VARCHAR NOT NULL, 
+    email VARCHAR, 
+    CONSTRAINT pk_user PRIMARY KEY (id), 
+    CONSTRAINT uq_user_email UNIQUE (email)
+);
+
+CREATE TABLE post (
+    id SERIAL NOT NULL, 
+    user_id INTEGER NOT NULL, 
+    timestamp TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
+    body VARCHAR NOT NULL, 
+    CONSTRAINT pk_post PRIMARY KEY (id), 
+    CONSTRAINT fk_post_user_id_user FOREIGN KEY(user_id) REFERENCES "user" (id)
+);
+
+INSERT INTO alembic_version (version_num) VALUES ('c0593ad90703') RETURNING alembic_version.version_num;
+
+COMMIT;
+

--- a/src/sl/dbserver/_test_app.py
+++ b/src/sl/dbserver/_test_app.py
@@ -7,6 +7,7 @@ import pytest as _pytest
 from . import app as _app
 from . import types as _types
 from .__test__.db import models as _m
+from .util import file as _file
 
 _TC = _ut.TestCase()
 
@@ -71,6 +72,42 @@ class TestSqlLoad:
         ]
 
     def test_load_sql_seed(self, sldb_conn):
+        all_users = sldb_conn.execute(_sa.select(_m.User)).all()
+        _TC.assertEqual(
+            all_users,
+            [
+                (1, "user1", "user1@email.com"),
+                (2, "user2", "user2@email.com"),
+            ],
+        )
+
+
+class TestSqlSchema:
+    @_pytest.fixture(scope="function")
+    def sldb_test_schema_def(self) -> _types.SchemaDef:
+        path_to_schema = _file.module_path("sl.dbserver.__test__:schema.sql")
+        return _types.SchemaDef(type="file", value=path_to_schema)
+
+    def test_load_sql_schema(self, sldb_conn):
+        all_users = sldb_conn.execute(_sa.select(_m.User)).all()
+        _TC.assertEqual(
+            all_users,
+            [
+                (1, "user1", "user1@email.com"),
+                (2, "user2", "user2@email.com"),
+            ],
+        )
+
+
+class TestRawSqlSchema:
+    @_pytest.fixture(scope="function")
+    def sldb_test_schema_def(self) -> _types.SchemaDef:
+        path_to_schema = _file.module_path("sl.dbserver.__test__:schema.sql")
+        with open(path_to_schema, "r") as f:
+            raw_sql = f.read()
+        return _types.SchemaDef(type="raw_sql", value=raw_sql)
+
+    def test_load_sql_schema(self, sldb_conn):
         all_users = sldb_conn.execute(_sa.select(_m.User)).all()
         _TC.assertEqual(
             all_users,

--- a/src/sl/dbserver/app.py
+++ b/src/sl/dbserver/app.py
@@ -1,12 +1,9 @@
 import fastapi as _fapi
 import datetime as _dt
-import sqlalchemy as _sa
-import sqlalchemy.engine as _sae
 from .util.db import (
     url as _dbu_url,
     conn as _dbu_conn,
 )
-from .util import file as _fu
 from . import (
     types as _types,
     db as _db,

--- a/src/sl/dbserver/conftest.py
+++ b/src/sl/dbserver/conftest.py
@@ -3,6 +3,7 @@ from .__test__.fixtures import (
     sldb_test_url,
     sldb_test_schema,
     sldb_test_schema_module,
+    sldb_test_schema_def,
     sldb_test_seed_data,
     sldb_test_reset_seq,
     sldb_url,

--- a/src/sl/dbserver/db.py
+++ b/src/sl/dbserver/db.py
@@ -16,6 +16,12 @@ def create_schema(url: _sae.URL | str, schema: _types.SchemaDef):
     match schema.type:
         case "sqlalchemy":
             _dbu_schema.load_sqlalchemy_schema(url, schema.value)
+        case "file":
+            with open(schema.value, "r") as f:
+                fdata = f.read()
+            _dbu_schema.load_sql_schema(url, fdata)
+        case "raw_sql":
+            _dbu_schema.load_sql_schema(url, schema.value)
 
 
 def _seed_data_from_file(fname: str) -> _types.SeedData:

--- a/src/sl/dbserver/types.py
+++ b/src/sl/dbserver/types.py
@@ -45,7 +45,7 @@ is running. eg: `/path/to/file.sql`.
 class SchemaDef(_pyd.BaseModel):
     """Define how to load the schema"""
 
-    type: _t.Literal["sqlalchemy"] = _pyd.Field(
+    type: _t.Literal["sqlalchemy", "file", "raw_sql"] = _pyd.Field(
         title="Type", description=_schemadef_type_desc
     )
     value: str = _pyd.Field(

--- a/src/sl/dbserver/util/db/schema.py
+++ b/src/sl/dbserver/util/db/schema.py
@@ -14,6 +14,13 @@ def load_sqlalchemy_schema(url: _sae.URL | str, value: str):
     metadata.create_all(engine)
 
 
+def load_sql_schema(url: _sae.URL | str, value: str):
+    engine = _sae.create_engine(url)
+    with engine.connect() as conn:
+        with conn.begin():
+            conn.execute(value)
+
+
 def metadata_from_str(metadata_str: str) -> _sa.MetaData:
     metadata = _fu.import_from_str(metadata_str)
     if not isinstance(metadata, _sa.MetaData):


### PR DESCRIPTION
This adds two alternative formats that can be used to load a schema; either from a path to a file containing raw SQL, or by passing the raw SQL directly in the value.